### PR TITLE
Offline

### DIFF
--- a/brainwidemap/bwm_loading.py
+++ b/brainwidemap/bwm_loading.py
@@ -118,7 +118,9 @@ def load_good_units(one, pid, compute_metrics=False, qc=1., **kwargs):
     one: one.api.ONE
         Instance to be used to connect to local or remote database
     pid: str
-        A probe insertion UUID
+        A probe insertion UUID.
+        If one is in local mode, it is ignored; in this case, `pname` and `eid` optional arguments should
+        be provided instead.
     compute_metrics: bool
         If True, force SpikeSortingLoader.merge_clusters to recompute the cluster metrics. Default is False
     qc: float
@@ -136,7 +138,12 @@ def load_good_units(one, pid, compute_metrics=False, qc=1., **kwargs):
     """
     eid = kwargs.pop('eid', '')
     pname = kwargs.pop('pname', '')
-    spike_loader = SpikeSortingLoader(pid=pid, one=one, eid=eid, pname=pname)
+    if one.mode == 'local':
+        if (eid is '') or (pname is ''):
+            raise ValueError('"eid" and "pname" optional arguments must be provided for ONE in local mode.')
+        spike_loader = SpikeSortingLoader(one=one, eid=eid, pname=pname)
+    else:
+        spike_loader = SpikeSortingLoader(pid=pid, one=one)
     download_good_units_only = qc >= 1.0
     spikes, clusters, channels = spike_loader.load_spike_sorting(revision="2024-05-06", good_units=download_good_units_only)
     clusters_labeled = SpikeSortingLoader.merge_clusters(

--- a/brainwidemap/bwm_loading.py
+++ b/brainwidemap/bwm_loading.py
@@ -139,7 +139,7 @@ def load_good_units(one, pid, compute_metrics=False, qc=1., **kwargs):
     eid = kwargs.pop('eid', '')
     pname = kwargs.pop('pname', '')
     if one.mode == 'local':
-        if (eid is '') or (pname is ''):
+        if (eid == '') or (pname == ''):
             raise ValueError('"eid" and "pname" optional arguments must be provided for ONE in local mode.')
         spike_loader = SpikeSortingLoader(one=one, eid=eid, pname=pname)
     else:


### PR DESCRIPTION
Problem: `load_good_units` returns error when ONE is in `local` mode.

The source of the problem is in `brainbox.io.one/one.py`:
```bash
    813 if self.pid is not None:                                                                                                                                                                                                       
    814     try:                                                                                                                                                                                                                       
    815         self.eid, self.pname = self.one.pid2eid(self.pid)                                                                                                                                                                      
    816     except NotImplementedError:                                                                                                                                                                                                
    817         if self.eid == '' or self.pname == '':                                                                                                                                                                                 
                                                                                                                                                                                                                                       
AttributeError: 'One' object has no attribute 'pid2eid'
```

Solution: added a check on the ONE mode in `load_good_units`; if ONE is in local mode, then `eid` and `pname` are passed to `SpikeSortingLoader` instead of `pid` -- which is ignored.